### PR TITLE
chore: use `-release` for managing module versions

### DIFF
--- a/classfile-fingerprint/pom.xml
+++ b/classfile-fingerprint/pom.xml
@@ -14,8 +14,7 @@
   <url>${project.parent.url}</url>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,8 +40,7 @@
   </scm>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/terminator-commons/pom.xml
+++ b/terminator-commons/pom.xml
@@ -14,8 +14,7 @@
   <url>${project.parent.url}</url>
 
   <properties>
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/watchdog-agent/pom.xml
+++ b/watchdog-agent/pom.xml
@@ -15,8 +15,7 @@
   <url>${project.parent.url}</url>
 
   <properties>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
+    <maven.compiler.release>17</maven.compiler.release>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 


### PR DESCRIPTION
We use `-release` for managing source and target versions because the latter are wrong. If you want to compile to earlier versions, you must set `-Xbootclasspath` to JDK11 otherwise it uses classes from the JVM running. Source: https://www.baeldung.com/java-source-target-options