### PR TITLE
refactor: prevent appending provenances to already existing JDK index

### DIFF
--- a/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/index/RuntimeIndexer.java
+++ b/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/index/RuntimeIndexer.java
@@ -118,9 +118,7 @@ public class RuntimeIndexer extends BaseIndexer implements Callable<Integer> {
                     ParsingHelper.deserializeFingerprints(indexFile.input.toPath());
 
             referenceProvenance.forEach((k, v) -> {
-                if (currentReferenceProvenance.containsKey(k)) {
-                    currentReferenceProvenance.get(k).addAll(v);
-                } else {
+                if (!currentReferenceProvenance.containsKey(k)) {
                     currentReferenceProvenance.put(k, v);
                 }
             });


### PR DESCRIPTION
Fixes #169 