### PR TITLE
fix: narrow down list of classes in log4j

### DIFF
--- a/classfile-fingerprint/src/test/java/io/github/algomaster99/terminator/index/SupplyChainIndexerTest.java
+++ b/classfile-fingerprint/src/test/java/io/github/algomaster99/terminator/index/SupplyChainIndexerTest.java
@@ -48,4 +48,19 @@ class SupplyChainIndexerTest {
         referenceProvenance.forEach((key, value) ->
                 assertThat(value.stream().findAny().get().algorithm()).isEqualTo("MD5"));
     }
+
+    @Test
+    void getAllClassesIn_log4jCore_log4jApi(@TempDir Path tempDir) {
+        // arrange
+        Path indexFile = tempDir.resolve("sc.json");
+        Path sbom = Path.of("src", "test", "resources", "supply-chain-index", "log4j-core.bom.json");
+
+        // act
+        String[] args = {"supply-chain", "-s", sbom.toString(), "-o", indexFile.toString()};
+        Index.main(args);
+
+        // assert
+        Map<String, Set<ClassFileAttributes>> referenceProvenance = ParsingHelper.deserializeFingerprints(indexFile);
+        assertThat(referenceProvenance.keySet().size()).isEqualTo(1273);
+    }
 }

--- a/classfile-fingerprint/src/test/java/io/github/algomaster99/terminator/index/SupplyChainIndexerTest.java
+++ b/classfile-fingerprint/src/test/java/io/github/algomaster99/terminator/index/SupplyChainIndexerTest.java
@@ -44,7 +44,7 @@ class SupplyChainIndexerTest {
 
         // assert
         Map<String, Set<ClassFileAttributes>> referenceProvenance = ParsingHelper.deserializeFingerprints(indexFile);
-        assertThat(referenceProvenance.keySet().size()).isEqualTo(20826);
+        assertThat(referenceProvenance.keySet().size()).isEqualTo(18929);
         referenceProvenance.forEach((key, value) ->
                 assertThat(value.stream().findAny().get().algorithm()).isEqualTo("MD5"));
     }

--- a/classfile-fingerprint/src/test/resources/supply-chain-index/log4j-core.bom.json
+++ b/classfile-fingerprint/src/test/resources/supply-chain-index/log4j-core.bom.json
@@ -1,0 +1,71 @@
+{
+  "$schema": "http://cyclonedx.org/schema/bom-1.5.schema.json",
+  "bomFormat": "CycloneDX",
+  "specVersion": "1.5",
+  "version": 1,
+  "components": [
+    {
+      "bom-ref": "org.example:log4shell-poc:1.0-SNAPSHOT",
+      "type": "application",
+      "group": "org.example",
+      "name": "log4shell-poc",
+      "version": "1.0-SNAPSHOT"
+    },
+    {
+      "bom-ref": "org.apache.logging.log4j:log4j-core:2.14.1",
+      "type": "library",
+      "group": "org.apache.logging.log4j",
+      "name": "log4j-core",
+      "version": "2.14.1",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "ade7402a70667a727635d5c4c29495f4ff96f061f12539763f6f123973b465b0"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "9141212b8507ab50a45525b545b39d224614528b"
+        },
+        {
+          "alg": "MD5",
+          "content": "948dda787593340a7af1a18e328b7b7f"
+        }
+      ]
+    },
+    {
+      "bom-ref": "org.apache.logging.log4j:log4j-api:2.14.1",
+      "type": "library",
+      "group": "org.apache.logging.log4j",
+      "name": "log4j-api",
+      "version": "2.14.1",
+      "hashes": [
+        {
+          "alg": "SHA-256",
+          "content": "8caf58db006c609949a0068110395a33067a2bad707c3da35e959c0473f9a916"
+        },
+        {
+          "alg": "SHA-1",
+          "content": "cd8858fbbde69f46bce8db1152c18a43328aae78"
+        },
+        {
+          "alg": "MD5",
+          "content": "6f31a3b90c3eb09fb0dc0aef155a001c"
+        }
+      ]
+    }
+  ],
+  "dependencies": [
+    {
+      "ref": "org.example:log4shell-poc:1.0-SNAPSHOT",
+      "dependsOn": [
+        "org.apache.logging.log4j:log4j-core:2.14.1"
+      ]
+    },
+    {
+      "ref": "org.apache.logging.log4j:log4j-core:2.14.1",
+      "dependsOn": [
+        "org.apache.logging.log4j:log4j-api:2.14.1"
+      ]
+    }
+  ]
+}

--- a/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/jar/JarDownloader.java
+++ b/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/jar/JarDownloader.java
@@ -47,6 +47,7 @@ public class JarDownloader {
                 .filter(c -> c.endsWith(".jar"))
                 .filter(c -> !c.contains("sources"))
                 .filter(c -> !c.contains("javadoc"))
+                .filter(c -> !c.contains("tests"))
                 .findFirst();
 
         if (artifactJar.isPresent()) {

--- a/watchdog-agent/pom.xml
+++ b/watchdog-agent/pom.xml
@@ -73,8 +73,8 @@
               <shadedPattern>rtf.com.fasterxml.jackson</shadedPattern>
             </relocation>
             <relocation>
-              <pattern>org.apache.log4j</pattern>
-              <shadedPattern>rtf.org.apache.log4j</shadedPattern>
+              <pattern>org.apache.logging.log4j</pattern>
+              <shadedPattern>rtf.org.apache.logging.log4j</shadedPattern>
             </relocation>
           </relocations>
         </configuration>


### PR DESCRIPTION
Fixes: #178 

The code was accidentally picking up the `tests` jar from maven central. Fixed it to get the correct jar.