### PR TITLE
feat: make exit forceful

### DIFF
--- a/watchdog-agent/src/main/java/io/github/algomaster99/Terminator.java
+++ b/watchdog-agent/src/main/java/io/github/algomaster99/Terminator.java
@@ -53,7 +53,7 @@ public class Terminator {
                     return classfileBuffer;
                 } else {
                     blueScreenOfDeath("[MODIFIED]: " + className);
-                    System.exit(1);
+                    Runtime.getRuntime().halt(1);
                     return null;
                 }
             }
@@ -63,7 +63,7 @@ public class Terminator {
             return classfileBuffer;
         } else {
             blueScreenOfDeath("[NOT ALLOWLISTED]: " + className);
-            System.exit(1);
+            Runtime.getRuntime().halt(1);
             return null;
         }
     }


### PR DESCRIPTION
`System.exit` is weaker than [`Runtime.halt(int)`](https://docs.oracle.com/en%2Fjava%2Fjavase%2F21%2Fdocs%2Fapi%2F%2F/java.base/java/lang/Runtime.html#halt(int)) because the former triggers shutdown hook while the latter does not care about them. Triggering shutdown hooks can cause deadlocks because application libraries could also have shutdown hooks that invoke `System.exit` and it causes a cyclic dependency. Thus, it is better to go for more forceful termination.

Source: https://www.baeldung.com/java-runtime-halt-vs-system-exit

@monperrus
`System.exit(int)` is equivalent to `SIGTERM`
`Runtime.halt(int)` is equivalent to `SIGKILL`