### PR TITLE
fix: based the name on fqn

### DIFF
--- a/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/fingerprint/classfile/ClassFileUtilities.java
+++ b/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/fingerprint/classfile/ClassFileUtilities.java
@@ -42,7 +42,7 @@ public class ClassFileUtilities {
 
         // sort the interfaces to make the name deterministic
         for (String i : Arrays.stream(interfaces).sorted().collect(Collectors.toList())) {
-            sb.append(getSimpleNameFromQualifiedName(i));
+            sb.append(i.replace("/", "_"));
         }
 
         return sb.toString();

--- a/terminator-commons/src/test/java/io/github/algomaster99/terminator/commons/fingerprint/classfile/ClassFileUtilitiesTest.java
+++ b/terminator-commons/src/test/java/io/github/algomaster99/terminator/commons/fingerprint/classfile/ClassFileUtilitiesTest.java
@@ -18,7 +18,7 @@ public class ClassFileUtilitiesTest {
         String moreReadableName = ClassFileUtilities.getInterfacesOfProxyClass(bytes);
 
         // assert
-        assertThat(moreReadableName).isEqualTo("Retention");
+        assertThat(moreReadableName).isEqualTo("java_lang_annotation_Retention");
     }
 
     @Test


### PR DESCRIPTION
Some proxy classes can be based on interfaces which have the same `simpleName` so we need to consider the fully qualified name.

Reference: #240 