### PR TITLE
refactor: do not rewrite field names

### DIFF
--- a/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/fingerprint/classfile/HashComputer.java
+++ b/terminator-commons/src/main/java/io/github/algomaster99/terminator/commons/fingerprint/classfile/HashComputer.java
@@ -12,7 +12,6 @@ public class HashComputer {
     public static String computeHash(byte[] bytes) {
         ConstantPoolParser parser = new ConstantPoolParser(bytes);
         parser.rewriteAllClassInfo()
-                .rewriteAllFieldRef()
                 .rewriteSourceFileAttribute()
                 .setNewName("Bar")
                 .modify();


### PR DESCRIPTION
The fields seems to be ordered (especially in Java 17) so we don't need to rewrite them.