### PR TITLE
test: run missing test for PDFBox

### DIFF
--- a/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/preprocess/PomTransformer.java
+++ b/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/preprocess/PomTransformer.java
@@ -108,10 +108,12 @@ public class PomTransformer {
         Xpp3Dom argLine = surefireConfiguration.getChild("argLine");
         if (argLine == null) {
             argLine = new Xpp3Dom("argLine");
-            argLine.setValue("-javaagent:" + AGENT_JAR + "=" + options.toString());
+            argLine.setValue(
+                    "--add-opens java.desktop/java.awt=ALL-UNNAMED -javaagent:" + AGENT_JAR + "=" + options.toString());
             surefireConfiguration.addChild(argLine);
         } else {
-            argLine.setValue("-javaagent:" + AGENT_JAR + "=" + options.toString() + " " + argLine.getValue());
+            argLine.setValue("--add-opens java.desktop/java.awt=ALL-UNNAMED -javaagent:" + AGENT_JAR + "="
+                    + options.toString() + " " + argLine.getValue());
         }
     }
 


### PR DESCRIPTION
These parameters allow invoking classes from `java.desktop` module. We need those classes for [PDFBox debugger](https://github.com/algomaster99/pdfbox/commit/a80578751a741006a674d1550a880456132554f8) test.