### PR TITLE
fix: record multiple attributes of runtime classes

### DIFF
--- a/runtime-class-interceptor/src/main/java/io/github/algomaster99/terminator/index/RuntimeClassInterceptor.java
+++ b/runtime-class-interceptor/src/main/java/io/github/algomaster99/terminator/index/RuntimeClassInterceptor.java
@@ -9,6 +9,7 @@ import java.lang.instrument.ClassFileTransformer;
 import java.lang.instrument.IllegalClassFormatException;
 import java.lang.instrument.Instrumentation;
 import java.security.ProtectionDomain;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;

--- a/runtime-class-interceptor/src/main/java/io/github/algomaster99/terminator/index/RuntimeClassInterceptor.java
+++ b/runtime-class-interceptor/src/main/java/io/github/algomaster99/terminator/index/RuntimeClassInterceptor.java
@@ -63,9 +63,10 @@ public class RuntimeClassInterceptor {
         }
         if (candidates == null) {
             exhaustiveListOfClasses.put(
-                    newClassName, Set.of(new ClassFileAttributes(classFileVersion, hash, "SHA-256")));
+                    newClassName, new HashSet<>(Set.of(new ClassFileAttributes(classFileVersion, hash, "SHA-256"))));
         } else {
             candidates.add(new ClassFileAttributes(classFileVersion, hash, "SHA-256"));
+            exhaustiveListOfClasses.put(newClassName, candidates);
         }
         return classfileBuffer;
     }


### PR DESCRIPTION
There is one class 'com/graphhopper/routing/weighting/custom/JaninoCustomWeightingHelperSubclass2' in `graphhopper` that is generated with different content in another execution.