### PR TITLE
feat: add option for modules not in graph of executable module

### DIFF
--- a/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/index/RuntimeIndexer.java
+++ b/classfile-fingerprint/src/main/java/io/github/algomaster99/terminator/index/RuntimeIndexer.java
@@ -52,7 +52,8 @@ public class RuntimeIndexer extends BaseIndexer implements Callable<Integer> {
 
     @CommandLine.Option(
             names = {"--related-modules"},
-            description = "The modules that are related to the executable jar module but are not dependencies or submodules to executable jar module",
+            description =
+                    "The modules that are related to the executable jar module but are not dependencies or submodules to executable jar module",
             required = false)
     private Set<String> relatedModules = new HashSet<>();
 


### PR DESCRIPTION
The modules that are related to the executable jar module but are not dependencies or submodules to executable jar module. For example, `batik-all` tests are included in `batik-test-old` and both of these modules are not related directly. So something like this is needed:
```shell
java -jar ../../sbom.exe-artifacts/classfile-fingerprint-*.jar runtime \
  -o /tmp/index.jsonl \
  -mj batik-all \
  -p batik \
  --related-modules batik-test-old
```